### PR TITLE
changed the id of fabric api in the README.md from fabric to fabric-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fabwork.json
 ```
 {
   "requiredModIds": [
-    "fabric", ...
+    "fabric-api", ...
   ]
 }
 ```


### PR DESCRIPTION
Fabric api's official ID has been changed to `fabric-api` to make more clear what mod is missing when a user forgets to install fabric api the ID `fabric` is still provided for compatibility https://github.com/FabricMC/fabric/blob/1.19.3/src/main/resources/fabric.mod.json but since the mod is not available for versions that are unaffected by that change It's probably a good idea to change the ID to `fabric-api` in the documentation

the change was made in https://github.com/FabricMC/fabric/releases/tag/0.59.0%2B1.19.2 and has been back ported to 1.18.2 in https://github.com/FabricMC/fabric/releases/tag/0.59.0%2B1.18.2